### PR TITLE
Correction "users" null si pas de "usersdemo" dans localStorage

### DIFF
--- a/app/readMe/readMe.controller.js
+++ b/app/readMe/readMe.controller.js
@@ -21,8 +21,12 @@
         ////////////////
 
         function activate() {        
-            vm.users = JSON.parse(window.localStorage.getItem('usersdemo'));
-            if(vm.users!=[]){
+          var storageUsers = JSON.parse(window.localStorage.getItem('usersdemo'));
+            if (storageUsers) {
+                vm.users = storageUsers;
+            }
+          
+            if(vm.users.length){
                 vm.showUsers = true;
             }
         }


### PR DESCRIPTION
Lors de la création des utilisateurs initiaux, au premier lancement de l'application, il n'y a pas de clé "usersdemo" dans le localStorage, du coup le tableau `vm.users` n'est plus vide mais égal à `null`.

Et donc lors de l'ajout d'un utilisateur nouvellement créé, on ne peut pas appeler `push` sur quelque chose qui n'est plus un tableau mais `null`, évidemment...

![image](https://cloud.githubusercontent.com/assets/5020707/16635218/afb5dcb6-43d1-11e6-86ac-072318d6d10c.png)

Du coup cette petite modification vérifie que la clé dans le localStorage existe bien avant de mettre à jour le tableau d'utilisateurs. C'est ballot, dès la première page, un bug... XD
